### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.8.0
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.8.0)** on 2024-12-16T09:47:41Z
